### PR TITLE
Allow passing Mime\Part as attachment

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -277,6 +277,13 @@ class MailService implements MailServiceInterface, EventManagerAwareInterface, M
         $attachmentParts    = [];
         $info               = new \finfo(FILEINFO_MIME_TYPE);
         foreach ($this->attachments as $key => $attachment) {
+            if (is_callable($attachment)) {
+                $attachment = $attachment();
+            }
+            if ($attachment instanceof Mime\Part) {
+                $attachmentParts[] = $attachment;
+                continue;
+            }
             if (! is_file($attachment)) {
                 continue; // If checked file is not valid, continue to the next
             }

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -277,6 +277,9 @@ class MailService implements MailServiceInterface, EventManagerAwareInterface, M
         $attachmentParts    = [];
         $info               = new \finfo(FILEINFO_MIME_TYPE);
         foreach ($this->attachments as $key => $attachment) {
+            if (is_string($attachment) && class_exists($attachment)) {
+                $attachment = new $attachment();
+            }
             if (is_callable($attachment)) {
                 $attachment = $attachment();
             }


### PR DESCRIPTION
I ran into this problem when trying to use the mailer library in conjunction with Flysytem. My use case is: how to use a file from the filesystem (using the read method, so basically the file as a string) directly into the email, without writing it to the local disk (in memory only).

This addition allow to pass the mime part through the attachments array:

```
$pdfFile = new Mime\Part($this->filesystem->read('file.pdf'));
$pdfFile->setType('application/pdf')
             ->setId('file.pdf')
            ->setFileName('file.pdf')
            ->setEncoding(Mime\Mime::ENCODING_BASE64)
            ->setDisposition(Mime\Mime::DISPOSITION_ATTACHMENT);

$this->mailService->addAttachments([
    'file.pdf' => $pdfFile,
]);
```

Another thing this modification allows is to attach files inline rather than as a full attachment, which is useful to add inline images to an email.

Adding the ability to pass a callable in is useful in order to define an inline image from the configuration file for instance:

```
'attachments' => [
    'files' => [
        'logo.png' => function () {
            $file = new \Zend\Mime\Part(file_get_contents('logo.png'));
            $file->setType('image/png')
                ->setId('logo.png')
                ->setFileName('logo.png')
                ->setEncoding(\Zend\Mime\Mime::ENCODING_BASE64)
                ->setDisposition(\Zend\Mime\Mime::DISPOSITION_INLINE)
            ;
            return $file;
        },
    ],
],
```

This change is compatible with version 5 and 6, and I would be keen to see it on V5 as I am currently working with ZF2.4 LTS :)